### PR TITLE
project detail page now correctly renders 

### DIFF
--- a/scripts/controllers/projectsController.js
+++ b/scripts/controllers/projectsController.js
@@ -13,8 +13,6 @@
     $('article').remove();
     $('section').hide();
     $('#project-detail').show();
-    $('#project-detail').children().hide(); //hides other projects
-    $('#' + ctx.params.projectname).show(); // shows only the project selected
   };
   module.projectsController = projectsController;
 })(window);

--- a/scripts/controllers/routes.js
+++ b/scripts/controllers/routes.js
@@ -1,6 +1,6 @@
 page('/', homeController.index);
-page('/projects', projectsController.retrieveData, projectsController.index);
 page('/projects/:projectname', projectsController.retrieveData, projectsController.detail);
+page('/projects', projectsController.retrieveData, projectsController.index);
 page('/contact', contactController.index);
 page('/blog', blogController.index);
 page();

--- a/scripts/views/portfolioView.js
+++ b/scripts/views/portfolioView.js
@@ -44,7 +44,11 @@
 
   portfolioView.initDetailPage = function() {
     Project.all.forEach(function(a){
-      $('#project-detail').append(a.toHtml($('#project-render-detail')));
+      var match = '/projects/' + a.projectUrl;
+      var strMatch = match.toString();
+      if (strMatch === window.location.pathname) {
+        $('#project-detail').append(a.toHtml($('#project-render-detail')));
+      }
     });
   };
   module.portfolioView = portfolioView;


### PR DESCRIPTION
Instead of rendering all project detail pages, it now only renders the correct one.

I'm not thrilled with how I solved this but it _does_ close #40 

Specifically, the detail render function now looks at window.location.pathname and only renders one where it matches the projectUrl from the JSON data; given that the projectUrl defines the pathname, that fits, I guess, but it feels like routing outside of Page and it doesn't feel robust to me. So - works, sure, could be better, should be better - just not sure how right now.

